### PR TITLE
feat: add activity view for sent transaction history

### DIFF
--- a/src/popup/Activity.tsx
+++ b/src/popup/Activity.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { TransactionRecord, WalletInfo } from '../core/wallet';
+
+interface ActivityProps {
+  records: TransactionRecord[];
+  wallet: WalletInfo;
+  onBack: () => void;
+}
+
+const Activity: React.FC<ActivityProps> = ({ records, wallet, onBack }) => {
+  const address = wallet.address.toLowerCase();
+  const sent = records.filter((r) => r.from.toLowerCase() === address);
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
+      <button onClick={onBack}>Back</button>
+      <h3>Activity</h3>
+      {sent.length === 0 ? (
+        <p>No sent transactions</p>
+      ) : (
+        <ul style={{ maxHeight: '150px', overflowY: 'auto', paddingLeft: '1rem' }}>
+          {sent.map((r) => (
+            <li key={r.hash}>
+              Sent {r.value} ETH to {r.to} ({r.status === 1 ? 'Success' : 'Fail'})
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+export default Activity;

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -12,8 +12,9 @@ import {
   NETWORKS,
   NetworkKey,
 } from '../core/wallet';
+import Activity from './Activity';
 
-type View = 'home' | 'import' | 'setPassword' | 'unlock' | 'wallet' | 'send';
+type View = 'home' | 'import' | 'setPassword' | 'unlock' | 'wallet' | 'send' | 'activity';
 
 const STORAGE_KEY = 'encryptedWallet';
 const SESSION_KEY = 'walletSession';
@@ -310,22 +311,8 @@ const Popup: React.FC = () => {
           <p><strong>Address:</strong> {walletInfo?.address}</p>
           <p><strong>Balance:</strong> {balance} ETH</p>
           <button onClick={() => setView('send')}>Send ETH</button>
+          <button onClick={() => setView('activity')}>Activity</button>
           <button onClick={logout}>Logout</button>
-          {history.length > 0 && (
-            <div>
-              <h3>History</h3>
-              <ul style={{ maxHeight: '100px', overflowY: 'auto', paddingLeft: '1rem' }}>
-                {history.map((h) => {
-                  const isSend = h.from.toLowerCase() === walletInfo?.address.toLowerCase();
-                  return (
-                    <li key={h.hash}>
-                      {isSend ? 'Sent' : 'Received'} {h.value} ETH {isSend ? `to ${h.to}` : `from ${h.from}`} ({h.status === 1 ? 'Success' : 'Fail'})
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          )}
         </div>
       )}
       {view === 'send' && (
@@ -344,6 +331,13 @@ const Popup: React.FC = () => {
           {sending && <p>Sending...</p>}
           <button onClick={() => setView('wallet')}>Cancel</button>
         </div>
+      )}
+      {view === 'activity' && walletInfo && (
+        <Activity
+          records={history}
+          wallet={walletInfo}
+          onBack={() => setView('wallet')}
+        />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- add Activity component to display wallet's sent transaction history
- provide Activity button from wallet view
## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897013ab5e8832cac3dd9529c804115